### PR TITLE
Fix bug that prevented messages via patternchannel from getting sent

### DIFF
--- a/redis_websocket_api/handler.py
+++ b/redis_websocket_api/handler.py
@@ -18,10 +18,11 @@ class WebsocketHandlerBase:
     read_timeout = NotImplemented
     allowed_commands = NotImplemented
 
-    def __init__(self, redis, websocket, channel_names, read_timeout=None):
+    def __init__(self, redis, websocket, channel_names, channel_patterns, read_timeout=None):
         self.websocket = websocket
         self.redis = redis
         self.channel_names = channel_names
+        self.channel_patterns = channel_patterns
         self.read_timeout = read_timeout or self.read_timeout
 
         self.queue = asyncio.Queue()
@@ -91,10 +92,18 @@ class WebsocketHandlerBase:
             raise RemoteMessageHandlerError(
                 "Handling message '{}' failed: {}".format(message, e)) from e
 
+    def _channel_in_patterns(self, channel_name):
+        return any(
+            [
+                True if pattern in channel_name else False
+                for pattern in self.channel_patterns
+            ]
+        )
+
     @classmethod
-    async def create(cls, redis, websocket, channel_names, read_timeout=None):
+    async def create(cls, redis, websocket, channel_names, channel_patterns, read_timeout=None):
         """Create a handler instance setting up tasks and queues."""
-        self = cls(redis, websocket, channel_names, read_timeout=read_timeout)
+        self = cls(redis, websocket, channel_names, channel_patterns, read_timeout=read_timeout)
         self.consumer_task = asyncio.ensure_future(self._websocket_reader())
         return self
 

--- a/redis_websocket_api/handler.py
+++ b/redis_websocket_api/handler.py
@@ -94,10 +94,9 @@ class WebsocketHandlerBase:
 
     def _channel_in_patterns(self, channel_name):
         return any(
-            [
-                True if pattern in channel_name else False
-                for pattern in self.channel_patterns
-            ]
+            # [:-1] because the patterns have a `*` at the end
+            pattern[:-1] in channel_name
+            for pattern in self.channel_patterns
         )
 
     @classmethod

--- a/redis_websocket_api/protocol.py
+++ b/redis_websocket_api/protocol.py
@@ -40,7 +40,7 @@ class CommandsMixin:
         If a client_ref is given, it is added to the envelope of the message
         sent.
         """
-        if channel_name not in self.channel_names and self._channel_in_patterns(channel_name):
+        if not (channel_name in self.channel_names or self._channel_in_patterns(channel_name)):
             return
 
         if ref is not None:

--- a/redis_websocket_api/protocol.py
+++ b/redis_websocket_api/protocol.py
@@ -40,7 +40,7 @@ class CommandsMixin:
         If a client_ref is given, it is added to the envelope of the message
         sent.
         """
-        if channel_name not in self.channel_names:
+        if channel_name not in self.channel_names and self._channel_in_patterns(channel_name):
             return
 
         if ref is not None:

--- a/redis_websocket_api/server.py
+++ b/redis_websocket_api/server.py
@@ -47,6 +47,7 @@ class WebsocketServer:
             self.redis,
             websocket,
             set(map(bytes.decode, self.receiver.channels.keys())),
+            set(map(bytes.decode, self.receiver.patterns.keys())),
             read_timeout=self.read_timeout,
         )
         self.handlers[websocket.remote_address] = handler

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(here, "requirements.txt")) as f:
 
 setup(
     name="redis-websocket-api",
-    version="0.0.4",
+    version="0.0.4.1",
     description="Redis-over-WebSocket API on top of websockets and aioredis",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(here, "requirements.txt")) as f:
 
 setup(
     name="redis-websocket-api",
-    version="0.0.4.1",
+    version="0.0.5",
     description="Redis-over-WebSocket API on top of websockets and aioredis",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ def redis():
 
 @pytest.fixture
 def handler(websocket, redis):
-    return WebsocketHandler(redis=redis, websocket=websocket, channel_names=[])
+    return WebsocketHandler(redis=redis, websocket=websocket, channel_names=[], channel_patterns=[])
 
 
 @pytest.fixture

--- a/tests/test_geo_protocol.py
+++ b/tests/test_geo_protocol.py
@@ -48,7 +48,7 @@ def geo_handler(websocket, redis):
     class GeoHandler(WebsocketHandler, GeoCommandsMixin):
         allowed_commands = "BBOX", "PROJECTION", "GET"
 
-    return GeoHandler(redis=redis, websocket=websocket, channel_names=[])
+    return GeoHandler(redis=redis, websocket=websocket, channel_names=[], channel_patterns=[])
 
 
 def test_bbox_command(loop, geo_handler):


### PR DESCRIPTION
This bug occured when a user sent a message to a channel that was pattern
subscribed to. Then, the _handle_get_command function would return None as the
channel that was requested was not in the allowed channel names.  
This was fixed by adding a check that returned True if the channel_name appeared
in the channel_patterns, thus passing that first test in _handle_get_command.