### PR TITLE
Subscribe to specific channel matched by pattern

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 geOps
+Copyright (c) 2018-2019 geOps
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/redis_websocket_api/server.py
+++ b/redis_websocket_api/server.py
@@ -78,11 +78,14 @@ class WebsocketServer:
         """Pass messages from subscribed channels to handlers."""
 
         async for channel, msg in self.receiver.iter(encoding="utf-8"):
+            if channel.is_pattern:
+                channel_name, msg = msg[0].decode(), msg[1]
+            else:
+                channel_name = channel.name.decode()
+
             for handler in self.handlers.values():
-                if channel.name.decode() in handler.subscriptions:
-                    handler.queue.put_nowait(
-                        Message(source=channel.name.decode(), content=msg)
-                    )
+                if channel_name in handler.subscriptions:
+                    handler.queue.put_nowait(Message(source=channel_name, content=msg))
 
     def listen(self, host, port, channel_names=None, channel_patterns=None, loop=None):
         """Listen for websocket connections and manage redis subscriptions."""

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(here, "requirements.txt")) as f:
 
 setup(
     name="redis-websocket-api",
-    version="0.0.5",
+    version="0.1.0",
     description="Redis-over-WebSocket API on top of websockets and aioredis",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Enable clients to subscribe to channels by name, that were
subscribed to by pattern in the WebsocketServer.

This could be used to subscribe to all redis channels starting with
"public" in the WebsocketServer and letting web clients subscribe to
them by name (e.g. with `SUB public_healthcheck`).

Bumping the version to 0.1 since this is a new exiting feature!