### PR TITLE
Update to more recent versions of pyproj

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ See `examples/demo.py` for how to use an extended `WebsocketHandler` subclass.
 Geo commands are currently limited to `LineString`, `Polygon`, and `Point`
 geometries.
 
+Note that the projection input and output coordinates will use the traditional GIS order,
+that is longitude, latitude for geographic CRS and easting, northing for most projected CRS.
+If you want the input and output axes order to strictly follow the definition of the CRS,
+use `StrictAxisOrderGeoCommandsMixin` instead of `GeoCommandsMixin`.
+
 #### Build your own protocol
 
 Using the commands listed above for communicating from client to server is

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ geometries.
 
 Note that the projection input and output coordinates will use the traditional GIS order,
 that is longitude, latitude for geographic CRS and easting, northing for most projected CRS.
-If you want the input and output axes order to strictly follow the definition of the CRS,
+If you want the input and output axis order to strictly follow the definition of the CRS,
 use `StrictAxisOrderGeoCommandsMixin` instead of `GeoCommandsMixin`.
 
 #### Build your own protocol

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(here, "README.md")) as f:
 
 setup(
     name="redis-websocket-api",
-    version="0.4.3",
+    version="0.4.4",
     description="Redis-over-WebSocket API on top of websockets and aioredis",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -21,7 +21,7 @@ setup(
     keywords="tralis websocket websockets aioredis redis",
     packages=["redis_websocket_api"],
     install_requires=["aioredis", "websockets", "hiredis"],
-    extras_require={"testing": ["pytest"], "geo": ["pyproj<2"]},
+    extras_require={"testing": ["pytest"], "geo": ["pyproj>=2.2.0"]},
     python_requires=">=3.7",
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Axis order is backward compatible by default but can be changed to strict mode by using the new `StrictAxisOrderGeoCommandsMixin` instead of `GeoCommandsMixin`. Tests still pass and there is a new test for strict axis order.

Tested with pyproj 2.2.0 (minimum required version) and 3.3.1 (current stable version).

Not sure about versioning the package (see setup.py).